### PR TITLE
modernize head

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <title>UX Engineer and beyond :)</title>
 
 <!-- Flow. -->
-<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 
 <!-- Love. -->
 <meta name="theme-color" content="#bae">
@@ -18,7 +18,7 @@
 <!-- Allure. -->
 <meta name="description" content="UX Engineer resume">
 <link rel="canonical" href="https://ryanve.github.io/uxe/">
-<link rel="shortcut icon" href="https://user-images.githubusercontent.com/949985/54581426-f76ed200-49c9-11e9-83ab-581b10243515.png">
+<link rel="icon" href="https://user-images.githubusercontent.com/949985/54581426-f76ed200-49c9-11e9-83ab-581b10243515.png">
 <meta property="og:image" content="https://user-images.githubusercontent.com/949985/54581426-f76ed200-49c9-11e9-83ab-581b10243515.png">
 <meta property="og:image:alt" content="lofi waves">
 


### PR DESCRIPTION
- `shrink-to-fit=no`  was [for Safari](https://stackoverflow.com/q/33767533/770127) but now seems obsolete
- [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types) says `shortcut` is non-conforming and ignored